### PR TITLE
Fix JaCoCo default configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,20 @@
 						<goals>
 							<goal>check</goal>
 						</goals>
+						<configuration>
+							<rules>
+								<rule>
+									<element>PACKAGE</element>
+									<limits>
+										<limit>
+											<counter>LINE</counter>
+											<value>COVEREDRATIO</value>
+											<minimum>0.50</minimum>
+										</limit>
+									</limits>
+								</rule>
+							</rules>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
This commit fixes JaCoCo configuration in order to have mvn install work.
Fixes: #93 