### PR TITLE
External jar loading issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<configuration>
 					<executable>true</executable>
+					<layout>ZIP</layout>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/rpm/SOURCES/cdmi-server.service
+++ b/rpm/SOURCES/cdmi-server.service
@@ -4,6 +4,7 @@ After=syslog.target
 
 [Service]
 User=cdmi
+Environment=JAVA_OPTS=-Dloader.path=/usr/lib/cdmi-server/plugins/
 ExecStart=/var/lib/cdmi-server/cdmi-server-1.2.jar
 SuccessExitStatus=143
 

--- a/rpm/SPECS/cdmi-server.spec
+++ b/rpm/SPECS/cdmi-server.spec
@@ -29,6 +29,7 @@ Standalone Spring Boot application version.
 mkdir -p %{buildroot}/usr/local/man/man8
 mkdir -p %{buildroot}/var/lib/%{name}/config
 mkdir -p %{buildroot}/etc/systemd/system
+mkdir -p %{buildroot}/usr/lib/%{name}/plugins
 cp %{_topdir}/SOURCES/cdmi-server.8.gz %{buildroot}/usr/local/man/man8
 cp %{_topdir}/SOURCES/application.yml %{buildroot}/var/lib/%{name}/config
 cp %{_topdir}/SOURCES/%{name}-%{jarversion}.jar %{buildroot}/var/lib/%{name}
@@ -39,6 +40,7 @@ cp %{_topdir}/SOURCES/%{name}.service %{buildroot}/etc/systemd/system
 /var/lib/%{name}/config/application.yml
 /var/lib/%{name}/%{name}-%{jarversion}.jar
 /etc/systemd/system/%{name}.service
+%dir /usr/lib/%{name}/plugins
 
 %changelog
 

--- a/rpm/SPECS/cdmi-server.spec
+++ b/rpm/SPECS/cdmi-server.spec
@@ -30,6 +30,7 @@ mkdir -p %{buildroot}/usr/local/man/man8
 mkdir -p %{buildroot}/var/lib/%{name}/config
 mkdir -p %{buildroot}/etc/systemd/system
 mkdir -p %{buildroot}/usr/lib/%{name}/plugins
+mkdir -p %{buildroot}/etc/%{name}/plugins
 cp %{_topdir}/SOURCES/cdmi-server.8.gz %{buildroot}/usr/local/man/man8
 cp %{_topdir}/SOURCES/application.yml %{buildroot}/var/lib/%{name}/config
 cp %{_topdir}/SOURCES/%{name}-%{jarversion}.jar %{buildroot}/var/lib/%{name}
@@ -41,6 +42,7 @@ cp %{_topdir}/SOURCES/%{name}.service %{buildroot}/etc/systemd/system
 /var/lib/%{name}/%{name}-%{jarversion}.jar
 /etc/systemd/system/%{name}.service
 %dir /usr/lib/%{name}/plugins
+%dir /etc/%{name}/plugins
 
 %changelog
 


### PR DESCRIPTION
### Problem description

Using ```-cp``` option to load external jar when launching CMDI server application fails.
The unique way I found (thanks to @bertl4398) to make the CDMI server executable jar "see" the external jar plugin is by moving the plugin into JAVA external lib directory ```$JAVA_HOME/jre/lib/ext``` or redefine/extend it using ```-Djava.ext.dirs=PLUGIN_DIRECTORY```.

### Analysis

The reason why the extension of classpath doesn't work is related to our executable jar.
CDMI application is a spring-boot executable jar, that supports three kinds of ```.class``` files loader: ```JarLauncher```, ```WarLauncher``` and ```PropertiesLauncher```. In the first two cases the use of additional locations is not supported because only the nested jars are loaded. The use of additional locations (directories or files) is supported by the ```PropertiesLauncher```. External jars, like our backend plugins, can be loaded through the ```-Dloader.path``` variable.

From [E.4 PropertiesLauncher Features](https://docs.spring.io/spring-boot/docs/current/reference/html/executable-jar.html#executable-jar-property-launcher-features):

> The ```PropertiesLauncher``` looks in ```BOOT-INF/lib/``` in your application archive by default, but you can add additional locations by setting an environment variable ```LOADER_PATH``` or ```loader.path``` in ```loader.properties``` (comma-separated list of directories, archives, or directories within archives). 

Specifying the plugin directory by adding a ```loader.path``` value would be a cleaner and more portable solution. But it doesn't work.

### Solution

The ```loader.path``` issue is due to a misconfiguration of maven spring boot plugin. In fact, to use ```PropertiesLauncher``` instead of ```JarLauncher``` we have to change the layout from JAR to ZIP, as explained by the [plugin documentation](http://docs.spring.io/spring-boot/docs/current/maven-plugin/usage.html): 

> ```ZIP``` (alias to ```DIR```): similar to the ```JAR``` layout using ```PropertiesLauncher```.

```
<plugin>
	<groupId>org.springframework.boot</groupId>
	<artifactId>spring-boot-maven-plugin</artifactId>
	<configuration>
		<executable>true</executable>
		<layout>ZIP</layout>
	</configuration>
</plugin>
```

Having updated this, we can set, for example, a directory where look for the plugins:

```JAVA_OPTS=-Dloader.path=/usr/lib/cdmi-server/plugins/```

Running again the CDMI server all started working.

### Extra

Having seen the .spec file of ```cdmi-hpss``` plugin, I moved into the CDMI .spec file the creation of:
- the plugins jar directory ```/usr/lib/cdmi-server/plugins```
- the plugins configuration directory ```/etc/cdmi-server/plugins```

I have also updated the ```cdmi-server.service``` file to include into the classpath the plugin directory.