### PR TITLE
Improve OIDCAuthenticationFilter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,10 @@
 			<artifactId>spring-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-jwt</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
 		</dependency>

--- a/src/main/java/edu/kit/scc/auth/OidcAuthenticationFilter.java
+++ b/src/main/java/edu/kit/scc/auth/OidcAuthenticationFilter.java
@@ -9,8 +9,14 @@
 
 package edu.kit.scc.auth;
 
-import edu.kit.scc.http.HttpClient;
-import edu.kit.scc.http.HttpResponse;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Date;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -18,18 +24,18 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.jwt.Jwt;
+import org.springframework.security.jwt.JwtHelper;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import java.io.IOException;
-
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import edu.kit.scc.http.HttpClient;
+import edu.kit.scc.http.HttpResponse;
 
 @Component
 public class OidcAuthenticationFilter extends OncePerRequestFilter {
@@ -71,45 +77,86 @@ public class OidcAuthenticationFilter extends OncePerRequestFilter {
    * @return true if authorized
    */
   public boolean verifyAuthorization(String authorizationHeader) {
-    try {
-      String authorizationMethod = authorizationHeader.split(" ")[0];
-      String encodedCredentials = authorizationHeader.split(" ")[1];
 
-      if (authorizationMethod.equals("Bearer")) {
-        // check for user token
-        HttpResponse response = httpClient.makeHttpsGetRequest(encodedCredentials, userInfo);
-        if (response != null && response.statusCode == HttpStatus.OK.value()) {
-          log.debug("User info {}", response.getResponseString());
-          String user = "user";
+    String authorizationMethod = authorizationHeader.split(" ")[0];
+    String encodedCredentials = authorizationHeader.split(" ")[1];
 
-          JSONObject json = new JSONObject(response.getResponseString());
-          user = json.optString("sub", "user");
-
-          UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(user,
-              encodedCredentials, AuthorityUtils.commaSeparatedStringToAuthorityList("ROLE_USER"));
-          auth.setDetails(json);
-
-          SecurityContextHolder.getContext().setAuthentication(auth);
-
-          return true;
-        }
-        // check for client token
-        String body = "token=" + encodedCredentials;
-        response = httpClient.makeHttpsPostRequest(clientId, clientSecret, body, tokenInfo);
-        if (response.statusCode == HttpStatus.OK.value()) {
-          log.debug("Token info {}", response.getResponseString());
-
-          SecurityContextHolder.getContext().setAuthentication(
-              new UsernamePasswordAuthenticationToken("client", encodedCredentials,
-                  AuthorityUtils.commaSeparatedStringToAuthorityList("ROLE_CLIENT")));
-
-          return true;
-        }
-      }
-    } catch (Exception ex) {
-      log.error("ERROR {}", ex.toString());
-      // ex.printStackTrace();
+    if (!authorizationMethod.equals("Bearer")) {
+      // not a token
+      return false;
     }
-    return false;
+
+    try {
+
+      Jwt jsonWebToken = JwtHelper.decode(encodedCredentials);
+      log.debug("jsonWebToken: {}", jsonWebToken);
+
+      JSONObject claims = new JSONObject(jsonWebToken.getClaims());
+
+      Date expiration = new Date(claims.getLong("exp") * 1000); // exp is in seconds
+      log.debug("Expiration date: {}", expiration);
+
+      if (expiration.before(new Date())) {
+        log.info("Token expired at {}", expiration);
+        return false;
+      }
+
+      String principal = claims.getString("sub");
+      AbstractAuthenticationToken auth = null;
+      JSONObject authDetails = new JSONObject();
+      Collection<? extends GrantedAuthority> authorities = null;
+
+      // get introspection endpoint data
+      String body = "token=" + encodedCredentials;
+      HttpResponse response =
+          httpClient.makeHttpsPostRequest(clientId, clientSecret, body, tokenInfo);
+
+      if (response == null) {
+        log.error("Null response received from {}", tokenInfo);
+        return false;
+      }
+
+      if (response.getStatusCode() == HttpStatus.OK.value()) {
+
+        log.debug("Token info {}", response.getResponseString());
+        authDetails.put("tokeninfo", new JSONObject(response.getResponseString()));
+
+        authorities = AuthorityUtils.commaSeparatedStringToAuthorityList("ROLE_CLIENT");
+
+      } else {
+
+        log.info("Introspection endpoint response: {}", response.getResponseString());
+        return false;
+      }
+
+      // get user info
+      response = httpClient.makeHttpsGetRequest(encodedCredentials, userInfo);
+
+      if (response == null) {
+        log.error("Null response received from {}", userInfo);
+        return false;
+      }
+
+      if (response.statusCode == HttpStatus.OK.value()) {
+
+        log.debug("User info {}", response.getResponseString());
+        authDetails.put("userinfo", new JSONObject(response.getResponseString()));
+
+        authorities = AuthorityUtils.commaSeparatedStringToAuthorityList("ROLE_USER");
+
+      }
+
+      auth = new UsernamePasswordAuthenticationToken(principal, encodedCredentials, authorities);
+      auth.setDetails(authDetails);
+
+      SecurityContextHolder.getContext().setAuthentication(auth);
+
+    } catch (Throwable ex) {
+
+      log.error("ERROR {}", ex.toString());
+      return false;
+    }
+
+    return true;
   }
 }

--- a/src/main/java/edu/kit/scc/auth/OidcAuthenticationFilter.java
+++ b/src/main/java/edu/kit/scc/auth/OidcAuthenticationFilter.java
@@ -85,9 +85,11 @@ public class OidcAuthenticationFilter extends OncePerRequestFilter {
           JSONObject json = new JSONObject(response.getResponseString());
           user = json.optString("sub", "user");
 
-          SecurityContextHolder.getContext()
-              .setAuthentication(new UsernamePasswordAuthenticationToken(user, encodedCredentials,
-                  AuthorityUtils.commaSeparatedStringToAuthorityList("ROLE_USER")));
+          UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(user,
+              encodedCredentials, AuthorityUtils.commaSeparatedStringToAuthorityList("ROLE_USER"));
+          auth.setDetails(json);
+
+          SecurityContextHolder.getContext().setAuthentication(auth);
 
           return true;
         }


### PR DESCRIPTION
It could be very useful to improve [OIDCAuthenticationFilter](https://github.com/indigo-dc/CDMI/blob/master/src/main/java/edu/kit/scc/auth/OidcAuthenticationFilter.java#L35) by adding:

- JWT token expiration check without querying IAM
- Authentication details set with userinfo and tokeninfo responses

Other improvements, not added by this pull request, could be:

- signature validation
- caching responses to better scale and not fulfill IAM with lots of requests
     - a cached httpClient (more info [here](https://hc.apache.org/httpcomponents-client-ga/tutorial/html/caching.html)) could be used for example 